### PR TITLE
Keep screen on using android:keepScreenOn attribute

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS"/>
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>
     <uses-permission android:name="android.permission.USE_CREDENTIALS"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
 
     <application android:icon="@drawable/icon" android:label="@string/app_name" android:name=".GaugesApplication" android:theme="@style/Theme.Gauges">
         <activity android:name=".ui.GaugeListActivity">

--- a/app/res/layout/airtraffic_activity.xml
+++ b/app/res/layout/airtraffic_activity.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
+    android:keepScreenOn = "true"
     android:background="@color/background" >
 
     <com.github.mobile.gauges.ui.airtraffic.AirTrafficView

--- a/app/src/main/java/com/github/mobile/gauges/ui/airtraffic/AirTrafficActivity.java
+++ b/app/src/main/java/com/github/mobile/gauges/ui/airtraffic/AirTrafficActivity.java
@@ -1,14 +1,11 @@
 package com.github.mobile.gauges.ui.airtraffic;
 
 import static android.os.Build.VERSION.SDK_INT;
-import static android.os.PowerManager.FULL_WAKE_LOCK;
 import static android.view.View.STATUS_BAR_HIDDEN;
 import static com.github.mobile.gauges.R.layout.airtraffic_activity;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
-import android.os.PowerManager;
-import android.os.PowerManager.WakeLock;
 import android.support.v4.app.LoaderManager.LoaderCallbacks;
 import android.support.v4.content.Loader;
 import android.widget.ImageView;
@@ -36,8 +33,6 @@ import roboguice.inject.InjectView;
  */
 public class AirTrafficActivity extends RoboFragmentActivity implements LoaderCallbacks<List<Gauge>> {
 
-    private static final String TAG = "ATA";
-
     private static final String PUSHER_APP_KEY = "887bd32ce6b7c2049e0b";
 
     @Inject
@@ -63,15 +58,10 @@ public class AirTrafficActivity extends RoboFragmentActivity implements LoaderCa
 
     private AirTrafficResourceProvider resourceProvider;
 
-    private WakeLock wakeLock;
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(airtraffic_activity);
-
-        wakeLock = ((PowerManager) getSystemService(POWER_SERVICE)).newWakeLock(FULL_WAKE_LOCK, TAG);
-        wakeLock.acquire();
 
         resourceProvider = new AirTrafficResourceProvider(getResources());
 
@@ -98,12 +88,6 @@ public class AirTrafficActivity extends RoboFragmentActivity implements LoaderCa
         super.onResume();
         airTrafficView.resume();
         subscribeToGaugeChannels(gauges.values());
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        wakeLock.release();
     }
 
     @Override


### PR DESCRIPTION
Hi @kevinsawicki - I wanted to check this tweak is good with you, unless you've already tried and rejected it?

Using `android:keepScreenOn` (which is added here to the airtraffic layout xml) doesn't require asking for the additional
WAKE_LOCK permission and also removes responsibility for managing the lock (the WindowManager takes care of keeping the sceen on so long as the activity shows) so I think it's generally preferred to the PowerManager method.

Tested on Galaxy Nexus - kept the screen on for the 5 minutes or so I was
watching it.

http://stackoverflow.com/questions/4376902/difference-between-wakelock-and-flag-keep-screen-on
http://stackoverflow.com/questions/2131948/force-screen-on
http://www.youtube.com/watch?v=OUemfrKe65c#t=1850s
http://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_KEEP_SCREEN_ON

reverts commit 83f18db9bd428a29d7f9ec178a517c9f2fc0e3c6.
