### PR TITLE
Rotate Refresh Item While Loading Things

### DIFF
--- a/app/res/anim/clockwise_refresh.xml
+++ b/app/res/anim/clockwise_refresh.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2012 GitHub Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<rotate xmlns:android="http://schemas.android.com/apk/res/android"
+        android:fromDegrees="0"
+        android:toDegrees="360"
+        android:pivotX="50%"
+        android:pivotY="50%"
+        android:duration="1000"
+        android:interpolator="@android:anim/linear_interpolator" />

--- a/app/res/layout/refresh_action_view.xml
+++ b/app/res/layout/refresh_action_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2012 GitHub Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:src="@drawable/ic_action_refresh"
+              style="@style/Widget.Sherlock.ActionButton" />

--- a/app/src/main/java/com/github/mobile/gauges/ui/ListLoadingFragment.java
+++ b/app/src/main/java/com/github/mobile/gauges/ui/ListLoadingFragment.java
@@ -18,16 +18,23 @@ package com.github.mobile.gauges.ui;
 
 import static com.github.mobile.gauges.ui.ToastUtil.toastOnUiThread;
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.LoaderManager.LoaderCallbacks;
 import android.support.v4.content.Loader;
 import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
+import android.view.LayoutInflater;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
+import android.widget.ImageView;
 import android.widget.ListAdapter;
 import android.widget.Toast;
 
+import com.github.mobile.gauges.R.anim;
 import com.github.mobile.gauges.R.id;
+import com.github.mobile.gauges.R.layout;
 import com.github.mobile.gauges.R.menu;
 
 import java.util.List;
@@ -40,6 +47,8 @@ import roboguice.fragment.RoboListFragment;
  * @param <E>
  */
 public abstract class ListLoadingFragment<E> extends RoboListFragment implements LoaderCallbacks<List<E>> {
+
+    private MenuItem refreshItem;
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
@@ -63,6 +72,7 @@ public abstract class ListLoadingFragment<E> extends RoboListFragment implements
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
         case id.refresh:
+            refreshItem = item;
             refresh();
             return true;
         default:
@@ -74,8 +84,19 @@ public abstract class ListLoadingFragment<E> extends RoboListFragment implements
      * Refresh the fragment's list
      */
     public void refresh() {
-        if (getActivity() != null)
+        if (getActivity() != null) {
+            /* Attach a rotating ImageView to the refresh item as an ActionView */
+            LayoutInflater inflater = (LayoutInflater) getActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            ImageView iv = (ImageView) inflater.inflate(layout.refresh_action_view, null);
+
+            Animation rotation = AnimationUtils.loadAnimation(getActivity(), anim.clockwise_refresh);
+            rotation.setRepeatCount(Animation.INFINITE);
+            iv.startAnimation(rotation);
+
+            refreshItem.setActionView(iv);
+
             getLoaderManager().restartLoader(0, null, this);
+        }
     }
 
     public void onLoadFinished(Loader<List<E>> loader, List<E> items) {
@@ -85,6 +106,11 @@ public abstract class ListLoadingFragment<E> extends RoboListFragment implements
             setListShown(true);
         else
             setListShownNoAnimation(true);
+
+        if (refreshItem != null && refreshItem.getActionView() != null) {
+            refreshItem.getActionView().clearAnimation();
+            refreshItem.setActionView(null);
+        }
     }
 
     /**


### PR DESCRIPTION
As per #8, this adds visual indication that something is happening after pressing the refresh item. It also looks better than swapping it out for a ProgressBar, IMO.

Signed-off-by: Eddie Ringle eddie@eringle.net
