### PR TITLE
Added Gradle support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ gen-external-apklibs
 .idea
 out
 .DS_Store
-
+.gradle
+build


### PR DESCRIPTION
ADT 22.0+ and Android Studio uses Gradle as the build system.
